### PR TITLE
Travis Python version update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 python:
-- 2.7
 - 3.5
+- 3.8
 cache:
 - pip
 install:

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ def package_data(pkg, roots):
 
 setup(
     name='edx-zoom',
-    version='1.5',
+    version='1.6',
     description='This XBlock implements the LTI interface for Zoom video conferencing.',
     packages=[
         'edx_zoom',


### PR DESCRIPTION
**Issue:** [BOM-1547](https://openedx.atlassian.net/browse/BOM-1547)

### Description
- Removed `Python2.7` and added `Python3.8` in `Travis`.
- No tests present in the repo.
- Updated version to `1.6`.