### PR TITLE
Updated the build status badge to point to travis-ci.com

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,8 +6,8 @@ TBD: Add details here.
 
 
 
-.. |Build Status| image:: https://travis-ci.org/edx/edx-zoom.svg
-  :target: https://travis-ci.org/edx/edx-zoom
+.. |Build Status| image:: https://travis-ci.com/edx/edx-zoom.svg
+  :target: https://travis-ci.com/edx/edx-zoom
 
 .. |Coveralls| image:: https://coveralls.io/repos/edx/edx-zoom/badge.svg?branch=master&service=github
   :target: https://coveralls.io/github/edx/edx-zoom?branch=master


### PR DESCRIPTION
Updated the README file.
Build status badge is now pointing to 'travis-ci.com' instead of 'travis-ci.org'
JIRA: https://openedx.atlassian.net/browse/BOM-2089